### PR TITLE
Change board FQBN option in example Makefile following breaking change

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 
 DEST := $(if $(DEST),$(DEST),gate)
-BOARD := "esp8266:esp8266:generic:FlashSize=2M"
+BOARD := "esp8266:esp8266:generic:eesz=2M"
 
 
 LOCAL_C_SRCS    ?= $(wildcard *.c)


### PR DESCRIPTION
The esp8266/Arduino core project introduced breaking changes to the command line options and changed the 'FlashSize' parameter to 'eesz' instead.

The upstream Arduino change is explained here: https://github.com/esp8266/Arduino/issues/5572

The Makefile in the `example/` folder should be updated